### PR TITLE
Use @inertiajs/react link instead of regular ones

### DIFF
--- a/resources/js/components/navbar.tsx
+++ b/resources/js/components/navbar.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@heroui/button";
 import { Kbd } from "@heroui/kbd";
 import { Link } from "@heroui/link";
+import { Link as InternalLink } from '@inertiajs/react';
 import { Input } from "@heroui/input";
 import {
   Navbar as HeroUINavbar,
@@ -12,7 +13,6 @@ import {
   NavbarMenuItem,
 } from "@heroui/navbar";
 import { link as linkStyles } from "@heroui/theme";
-import { Link as InternalLink } from '@inertiajs/react';
 import clsx from "clsx";
 
 import { siteConfig } from "@/config/site";

--- a/resources/js/components/navbar.tsx
+++ b/resources/js/components/navbar.tsx
@@ -12,6 +12,7 @@ import {
   NavbarMenuItem,
 } from "@heroui/navbar";
 import { link as linkStyles } from "@heroui/theme";
+import { Link as InternalLink } from '@inertiajs/react';
 import clsx from "clsx";
 
 import { siteConfig } from "@/config/site";
@@ -63,7 +64,7 @@ export const Navbar = () => {
         <div className="hidden lg:flex gap-4 justify-start ml-2">
           {siteConfig.navItems.map((item) => (
             <NavbarItem key={item.href}>
-              <Link
+              <InternalLink
                 className={clsx(
                   linkStyles({ color: "foreground" }),
                   "data-[active=true]:text-primary data-[active=true]:font-medium",
@@ -72,7 +73,7 @@ export const Navbar = () => {
                 href={item.href}
               >
                 {item.label}
-              </Link>
+              </InternalLink>
             </NavbarItem>
           ))}
         </div>

--- a/resources/js/components/navbar.tsx
+++ b/resources/js/components/navbar.tsx
@@ -52,7 +52,7 @@ export const Navbar = () => {
     <HeroUINavbar maxWidth="xl" position="sticky">
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
         <NavbarBrand className="gap-3 max-w-fit">
-          <Link
+          <InternalLink
             className="flex justify-start items-center gap-1"
             color="foreground"
             href="/"


### PR DESCRIPTION
Use @inertiajs/react link instead of regular ones to take advantage of SPA features.

More details: using regular links causes page reloads, pull request solves this problem.